### PR TITLE
fix jupyterq_licensemgr to support kdb+ 4.0 banner

### DIFF
--- a/jupyterq_licensemgr/jupyterq_licensemgr/__init__.py
+++ b/jupyterq_licensemgr/jupyterq_licensemgr/__init__.py
@@ -55,7 +55,7 @@ def load_jupyter_server_extension(nb):
 			elif status == "host":
 				result['action'] = "license"
 				result['info'] = "Wrong hostname on license"
-			elif status == "kc.lic" or status == "k4.lic" or status == 'detected and no license found.': # no license, or corrupt license
+			elif status == "kc.lic" or status == "k4.lic" or status == 'detected and no license found.' or status == 'licence error: kc.lic' or status == 'licence error: k4.lic': # no license, or corrupt license
 				result['action'] = "license"
 				result['info'] = "Unlicensed workstation"
 			elif status == "ok":


### PR DESCRIPTION
Update jupyterq_licensemgr to support the slightly different banner format in 4.0.